### PR TITLE
tilt-starlark-codegen: fix package name

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ tilt-starlark-codegen ./pkg/apis/core/v1alpha1 -
 	// gofmt
 	result, err := imports.Process("", buf.Bytes(), nil)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Problem formatting output: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Problem gofmting output: %v\n", err)
 
 		// If we have a formatting error, we should still treat
 		// this as success and write to the file anyway.
@@ -97,7 +97,7 @@ tilt-starlark-codegen ./pkg/apis/core/v1alpha1 -
 		result = buf.Bytes()
 	}
 
-	out, err := codegen.OpenOutputFile(args[2])
+	out, outName, err := codegen.OpenOutputFile(args[2])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
@@ -108,6 +108,8 @@ tilt-starlark-codegen ./pkg/apis/core/v1alpha1 -
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
+
+	fmt.Fprintf(os.Stderr, "Wrote output to %s\n", outName)
 
 	closer, ok := out.(io.Closer)
 	if ok {


### PR DESCRIPTION
### Problem

When running `make update-starlark-codegen` in Tilt, this was the entirety of what it gave me:
```
Problem formatting output: 3:1: expected 'IDENT', found 'import'
```
This didn't give me a lot to go on!

### Solutions
1. log the location to which we wrote the generated code, both to a) communicate that we wrote it anyway and b) let the user inspect it to see what the problem might be
2. Change the actual code gen to fix the underlying issue - we're fetching the package from the universe using its local path, but the universe is looking that up in a map keyed by canonical path, and returns us a `Package` with an empty `Name`. The gofmt error is thus because the first line of the generated file is `package `, with no name.

### Notes
1. I haven't figured out why this was broken in the first place - I'm not clear if something changed that broke this, or if something differs on my machine than wherever `make update-starlark-codegen` was previously run, or if it was only previously run with the canonical path ("github.com/tilt-dev/" instead of local ("./")).
2. This project doesn't have tests and I didn't want to shave that yak in this PR, but I did run it against the tilt project and the diff looked good.