### PR TITLE
codegen: add support for aliases, Duration

### DIFF
--- a/internal/codegen/find.go
+++ b/internal/codegen/find.go
@@ -40,7 +40,7 @@ func findStructMembersHelper(t *types.Type, result map[string]*types.Type) {
 	}
 
 	for _, m := range t.Members {
-		if isTimeMember(m) {
+		if isTimeMember(m) || isDurationMember(m) {
 			continue
 		}
 

--- a/test/example/filewatch_types.go
+++ b/test/example/filewatch_types.go
@@ -57,6 +57,12 @@ type FileWatchSpec struct {
 
 	// Ignores are optional rules to filter out a subset of changes matched by WatchedPaths.
 	Ignores []IgnoreDef `json:"ignores,omitempty" protobuf:"bytes,2,rep,name=ignores"`
+
+	// Strategy for testing named strings.
+	Strategy FileWatchStrategy `json:"strategy,omitempty" protobuf:"bytes,3,opt,name=strategy"`
+
+	// Duration for testing metav1.Duration
+	Debounce metav1.Duration `json:"debounce,omitempty" protobuf:"bytes,4,opt,name=duration"`
 }
 
 type IgnoreDef struct {
@@ -142,3 +148,5 @@ type FileEvent struct {
 	// SeenFiles is a list of paths which changed (create, modify, or delete).
 	SeenFiles []string `json:"seenFiles" protobuf:"bytes,2,rep,name=seenFiles"`
 }
+
+type FileWatchStrategy string

--- a/test/golden/master.txt
+++ b/test/golden/master.txt
@@ -2,6 +2,7 @@ package example
 
 import (
 	"fmt"
+	"time"
 
 	"go.starlark.net/starlark"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,6 +64,8 @@ func (p Plugin) fileWatch(t *starlark.Thread, fn *starlark.Builtin, args starlar
 	}
 	var watchedPaths value.LocalPathList = value.NewLocalPathListUnpacker(t)
 	var ignores IgnoreDefList = IgnoreDefList{t: t}
+	var strategy string
+	var debounce value.Duration
 	var labels value.StringStringMap
 	var annotations value.StringStringMap
 	err = starkit.UnpackArgs(t, fn.Name(), args, kwargs,
@@ -71,6 +74,8 @@ func (p Plugin) fileWatch(t *starlark.Thread, fn *starlark.Builtin, args starlar
 		"annotations?", &annotations,
 		"watched_paths?", &watchedPaths,
 		"ignores?", &ignores,
+		"strategy?", &strategy,
+		"debounce?", &debounce,
 	)
 	if err != nil {
 		return nil, err
@@ -78,6 +83,8 @@ func (p Plugin) fileWatch(t *starlark.Thread, fn *starlark.Builtin, args starlar
 
 	obj.Spec.WatchedPaths = watchedPaths.Value
 	obj.Spec.Ignores = ignores.Value
+	obj.Spec.Strategy = example.FileWatchStrategy(strategy)
+	obj.Spec.Debounce = metav1.Duration{Duration: time.Duration(debounce)}
 	obj.ObjectMeta.Labels = labels
 	obj.ObjectMeta.Annotations = annotations
 	return p.register(t, obj)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/configmap:

022f3b09ebed3f36208bd34a90b8cec80b27caba (2021-10-08 20:42:46 -0400)
codegen: add support for aliases, Duration

f3ca48f59e5229f8551592f35e8479d4eef0daa8 (2021-10-07 17:59:14 -0400)
support types with a Data field instead of a Spec field

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics